### PR TITLE
Add vi-mode indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ## cbjohnson theme
 
-A minimal theme forked from the [yimmy][yimmy-commit] theme (thanks [jhillyerd][yimmy-author]!)
+A minimal theme forked from the oh-my-fish/theme-cbjohnson theme with elegant vi-mode indicator.
 
 ![screenshot](https://cloud.githubusercontent.com/assets/4823640/5327427/6f9e61bc-7d02-11e4-9223-38ddbed176c8.png)
-
-[yimmy-commit]: https://github.com/bpinto/oh-my-fish/tree/3a4b7de689cabf3522227f51177a489d915c8b4d/themes/yimmy
-[yimmy-author]: https://github.com/jhillyerd
+![screenshot](https://user-images.githubusercontent.com/15342165/42720301-58604070-8757-11e8-80ab-9c630c0083b0.png)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ A minimal theme forked from the oh-my-fish/theme-cbjohnson theme with elegant vi
 
 ![screenshot](https://cloud.githubusercontent.com/assets/4823640/5327427/6f9e61bc-7d02-11e4-9223-38ddbed176c8.png)
 ![screenshot](https://user-images.githubusercontent.com/15342165/42720301-58604070-8757-11e8-80ab-9c630c0083b0.png)
+![screenshot](https://user-images.githubusercontent.com/15342165/42831945-542be716-8a22-11e8-8e52-77321b5ee1a9.png)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A minimal theme forked from the oh-my-fish/theme-cbjohnson theme with elegant vi-mode indicator.
 
+Install with [fisherman](https://github.com/fisherman/fisherman) using command `fisher znculee/fish-theme-cbjohnson`.
+
+If the prompt_pwd shows abbreviated version even with enough space, you may add `set fish_prompt_pwd_dir_length 0` in your `~/.config/fish/config.fish`.
+
 ![screenshot](https://cloud.githubusercontent.com/assets/4823640/5327427/6f9e61bc-7d02-11e4-9223-38ddbed176c8.png)
 ![screenshot](https://user-images.githubusercontent.com/15342165/42720301-58604070-8757-11e8-80ab-9c630c0083b0.png)
 ![screenshot](https://user-images.githubusercontent.com/15342165/42831945-542be716-8a22-11e8-8e52-77321b5ee1a9.png)

--- a/fish_mode_prompt.fish
+++ b/fish_mode_prompt.fish
@@ -1,0 +1,2 @@
+function fish_mode_prompt
+end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -36,7 +36,7 @@ function fish_prompt
 
   # Top
   set fish_prompt_pwd_dir_length 0
-  set -l prompt_columns (echo -n $USER at $__fish_prompt_hostname in (prompt_pwd) (__fish_git_prompt) | wc -c)
+  set -l prompt_columns (printf '%s%s at %s in %s%s' $CONDA_PROMPT_MODIFIER $USER $__fish_prompt_hostname (prompt_pwd) (__fish_git_prompt) | wc -c)
   if test $prompt_columns -lt $COLUMNS
     echo -n $cyan$USER$normal at $yellow$__fish_prompt_hostname$normal in $bred(prompt_pwd)$normal
     set -g __fish_git_prompt_showcolorhints true
@@ -44,14 +44,14 @@ function fish_prompt
     echo
   else
     set fish_prompt_pwd_dir_length 1
-    set -l prompt_columns (echo -n $USER at $__fish_prompt_hostname in (prompt_pwd) (__fish_git_prompt) | wc -c)
+    set -l prompt_columns (printf '%s%s at %s in %s%s' $CONDA_PROMPT_MODIFIER $USER $__fish_prompt_hostname (prompt_pwd) (__fish_git_prompt) | wc -c)
     if test $prompt_columns -lt $COLUMNS
       echo -n $cyan$USER$normal at $yellow$__fish_prompt_hostname$normal in $bred(prompt_pwd)$normal
       set -g __fish_git_prompt_showcolorhints true
       __fish_git_prompt
       echo
     else
-      set -l prompt_columns (echo -n (prompt_pwd) (__fish_git_prompt) | wc -c)
+      set -l prompt_columns (printf '%s%s%s' $CONDA_PROMPT_MODIFIER (prompt_pwd) (__fish_git_prompt) | wc -c)
       if test $prompt_columns -lt $COLUMNS
         echo -n $bred(prompt_pwd)$normal
         set -g __fish_git_prompt_showcolorhints true

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -41,5 +41,25 @@ function fish_prompt
   echo
 
   # Bottom
-  echo -n $pcolor$__fish_prompt_char $normal
+  if test "$fish_key_bindings" = "fish_vi_key_bindings"
+    or test "$fish_key_bindings" = "fish_hybrid_key_bindings"
+    switch $fish_bind_mode
+      case default
+        set_color --bold red
+        echo -n '[N]'
+      case insert
+        set_color --bold green
+        echo -n '[I]'
+      case replace_one
+        set_color --bold green
+        echo -n '[R]'
+      case visual
+        set_color --bold brmagenta
+        echo -n '[V]'
+    end
+      set_color normal
+      echo -n $pcolor$__fish_prompt_char $normal
+  else
+    echo -n $pcolor$__fish_prompt_char $normal
+  end
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -24,18 +24,24 @@ function fish_prompt
   set -l bcyan (set_color -o cyan)
   set -l bwhite (set_color -o white)
 
-  # Configure __fish_git_prompt
-  set -g __fish_git_prompt_show_informative_status true
-  set -g __fish_git_prompt_showcolorhints true
-
   # Color prompt char red for non-zero exit status
   set -l pcolor $bpurple
   if [ $last_status -ne 0 ]
     set pcolor $bred
   end
 
+  # Configure __fish_git_prompt
+  set -g __fish_git_prompt_show_informative_status true
+  set -e __fish_git_prompt_showcolorhints
+
   # Top
+  set fish_prompt_pwd_dir_length 0
+  set -l prompt_columns (echo -n $USER at $__fish_prompt_hostname in (prompt_pwd) (__fish_git_prompt) | wc -c)
+  if test $prompt_columns -ge $COLUMNS
+    set fish_prompt_pwd_dir_length 1
+  end
   echo -n $cyan$USER$normal at $yellow$__fish_prompt_hostname$normal in $bred(prompt_pwd)$normal
+  set -g __fish_git_prompt_showcolorhints true
   __fish_git_prompt
 
   echo

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -37,14 +37,29 @@ function fish_prompt
   # Top
   set fish_prompt_pwd_dir_length 0
   set -l prompt_columns (echo -n $USER at $__fish_prompt_hostname in (prompt_pwd) (__fish_git_prompt) | wc -c)
-  if test $prompt_columns -ge $COLUMNS
+  if test $prompt_columns -lt $COLUMNS
+    echo -n $cyan$USER$normal at $yellow$__fish_prompt_hostname$normal in $bred(prompt_pwd)$normal
+    set -g __fish_git_prompt_showcolorhints true
+    __fish_git_prompt
+    echo
+  else
     set fish_prompt_pwd_dir_length 1
+    set -l prompt_columns (echo -n $USER at $__fish_prompt_hostname in (prompt_pwd) (__fish_git_prompt) | wc -c)
+    if test $prompt_columns -lt $COLUMNS
+      echo -n $cyan$USER$normal at $yellow$__fish_prompt_hostname$normal in $bred(prompt_pwd)$normal
+      set -g __fish_git_prompt_showcolorhints true
+      __fish_git_prompt
+      echo
+    else
+      set -l prompt_columns (echo -n (prompt_pwd) (__fish_git_prompt) | wc -c)
+      if test $prompt_columns -lt $COLUMNS
+        echo -n $bred(prompt_pwd)$normal
+        set -g __fish_git_prompt_showcolorhints true
+        __fish_git_prompt
+        echo
+      end
+    end
   end
-  echo -n $cyan$USER$normal at $yellow$__fish_prompt_hostname$normal in $bred(prompt_pwd)$normal
-  set -g __fish_git_prompt_showcolorhints true
-  __fish_git_prompt
-
-  echo
 
   # Bottom
   if test "$fish_key_bindings" = "fish_vi_key_bindings"


### PR DESCRIPTION
This pull request add a vi-mode indicator just before fish_prompt_char in the second line. And also disable the original vi-mode indicator by empty the fish_mode_prompt.fish. I think this kind of indicator is more elegant and suitable for this theme.
![image](https://user-images.githubusercontent.com/15342165/42720301-58604070-8757-11e8-80ab-9c630c0083b0.png)
